### PR TITLE
test: Add manual workflow dispatch test

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,0 +1,21 @@
+name: Manual Test Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_message:
+        description: "テストメッセージ"
+        required: false
+        default: "これはテストです"
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo test message
+        run: |
+          echo "📝 メッセージ: ${{ github.event.inputs.test_message }}"
+          echo "🌿 ブランチ: ${{ github.ref_name }}"
+          echo "👤 実行者: ${{ github.actor }}"
+          echo "✅ このワークフローは手動実行専用です"


### PR DESCRIPTION
## 目的
GitHub Actions の workflow_dispatch が feature ブランチと main ブランチでどのように表示されるかを検証するためのテストワークフローを追加。

## 検証結果（feature ブランチ）
- ✅ feature ブランチにワークフローをpush
- ❌ GitHub Actions UI の左サイドバーに「Manual Test Workflow」が表示されない
- **結論**: feature ブランチにあるだけでは UI に表示されない

## 次のステップ
main にマージ後、ワークフローが UI に表示されるか確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)