### PR TITLE
feat: Manual Test Workflowに環境選択機能を追加

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -3,6 +3,13 @@ name: Manual Test Workflow
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "デプロイ環境"
+        required: true
+        type: choice
+        options:
+          - dev
+          - stg
       test_message:
         description: "テストメッセージ"
         required: false
@@ -18,6 +25,7 @@ jobs:
           echo "=================================="
           echo "🟢 これは FEATURE ブランチのバージョンです"
           echo "=================================="
+          echo "🌍 環境: ${{ github.event.inputs.environment }}"
           echo "📝 メッセージ: ${{ github.event.inputs.test_message }}"
           echo "🌿 ブランチ: ${{ github.ref_name }}"
           echo "👤 実行者: ${{ github.actor }}"
@@ -28,3 +36,13 @@ jobs:
           echo "   - 新機能B: ログ出力の改善"
           echo "   - 新機能C: エラーハンドリングの強化"
           echo "✨ FEATURE ブランチの処理が完了しました"
+          echo ""
+          if [ "${{ github.event.inputs.environment }}" == "dev" ]; then
+            echo "🔧 DEV環境での処理:"
+            echo "   - デバッグモード有効"
+            echo "   - 詳細ログ出力"
+          elif [ "${{ github.event.inputs.environment }}" == "stg" ]; then
+            echo "🧪 STG環境での処理:"
+            echo "   - 本番同等設定"
+            echo "   - パフォーマンステスト実施"
+          fi

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -16,9 +16,15 @@ jobs:
       - name: Echo test message
         run: |
           echo "=================================="
-          echo "🔵 これは MAIN ブランチのバージョンです"
+          echo "🟢 これは FEATURE ブランチのバージョンです"
           echo "=================================="
           echo "📝 メッセージ: ${{ github.event.inputs.test_message }}"
           echo "🌿 ブランチ: ${{ github.ref_name }}"
           echo "👤 実行者: ${{ github.actor }}"
           echo "✅ このワークフローは手動実行専用です"
+          echo ""
+          echo "🚀 FEATURE ブランチ独自の処理を実行中..."
+          echo "   - 新機能A: データ処理の最適化"
+          echo "   - 新機能B: ログ出力の改善"
+          echo "   - 新機能C: エラーハンドリングの強化"
+          echo "✨ FEATURE ブランチの処理が完了しました"


### PR DESCRIPTION
## Summary
Manual Test Workflowに手動実行時にdev環境とstg環境を選択できる機能を追加しました。

## 変更内容
- `workflow_dispatch`に`environment`パラメータを追加（choice型）
- dev/stgの選択肢を提供
- 選択した環境に応じた処理を出力
  - dev環境: デバッグモード、詳細ログ出力
  - stg環境: 本番同等設定、パフォーマンステスト

## テスト方法
1. GitHubのActionsタブからManual Test Workflowを選択
2. 「Run workflow」をクリック
3. 「デプロイ環境」ドロップダウンからdevまたはstgを選択
4. 実行して、選択した環境に応じたメッセージが表示されることを確認

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)